### PR TITLE
Fix highlighting of long Unicode escape sequences

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -577,7 +577,7 @@
     'name': 'string.quoted.double.css'
     'patterns': [
       {
-        'match': '\\\\(\\d{1,6}|.)'
+        'match': '\\\\([a-fA-F0-9]{1,6}|.)'
         'name': 'constant.character.escape.css'
       }
     ]
@@ -593,7 +593,7 @@
     'name': 'string.quoted.single.css'
     'patterns': [
       {
-        'match': '\\\\.'
+        'match': '\\\\([a-fA-F0-9]{1,6}|.)'
         'name': 'constant.character.escape.css'
       }
     ]

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -60,3 +60,30 @@ describe 'CSS grammar', ->
       expect(lines[3][3]).toEqual value: ':', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'punctuation.separator.key-value.css']
       expect(lines[3][4]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css']
       expect(lines[3][5]).toEqual value: 'none', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.property-value.css']
+
+  describe 'character escapes', ->
+    it 'can handle long hexadecimal escape sequences in single-quoted strings', ->
+      {tokens} = grammar.tokenizeLine "very-custom { content: '\\c0ffee' }"
+
+      expect(tokens[0]).toEqual value: 'very-custom', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.custom.css']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['source.css', 'meta.selector.css']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.css']
+      expect(tokens[3]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css']
+      expect(tokens[4]).toEqual value: 'content', scopes: ['source.css', 'meta.property-list.css', 'meta.property-name.css', 'support.type.property-name.css']
+      expect(tokens[5]).toEqual value: ':', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'punctuation.separator.key-value.css']
+      expect(tokens[6]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css']
+      expect(tokens[7]).toEqual value: "'", scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'string.quoted.single.css', 'punctuation.definition.string.begin.css']
+      expect(tokens[8]).toEqual value: '\\c0ffee', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'string.quoted.single.css', 'constant.character.escape.css']
+
+    it 'can handle long hexadecimal escape sequences in double-quoted strings', ->
+      {tokens} = grammar.tokenizeLine 'very-custom { content: "\\c0ffee" }'
+
+      expect(tokens[0]).toEqual value: 'very-custom', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.custom.css']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['source.css', 'meta.selector.css']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.css']
+      expect(tokens[3]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css']
+      expect(tokens[4]).toEqual value: 'content', scopes: ['source.css', 'meta.property-list.css', 'meta.property-name.css', 'support.type.property-name.css']
+      expect(tokens[5]).toEqual value: ':', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'punctuation.separator.key-value.css']
+      expect(tokens[6]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css']
+      expect(tokens[7]).toEqual value: '"', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'string.quoted.double.css', 'punctuation.definition.string.begin.css']
+      expect(tokens[8]).toEqual value: '\\c0ffee', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'string.quoted.double.css', 'constant.character.escape.css']


### PR DESCRIPTION
The CSS specification states that hexadecimal escape sequences up to six digits long are allowed within both single- and double-quoted strings. Previously, double-quoted strings allowed up to six decimal digits, but not hexadecimal. And double-quoted strings didn't allow more than one character escape sequences.

This change unifies the pattern used for both single- and double-quoted strings. It also allows both string types to have escape sequences consisting of a backslash followed by any character or a backslash followed by one to six hexadecimal digits.

/cc @kevinsawicki 
