### PR TITLE
Add frequency units (Hz and kHz)

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -335,7 +335,7 @@
             'name': 'keyword.other.unit.css'
         'match': '(?x)
           (?<!\\w|-)(?:(?:-|\\+)?(?:[0-9]+(?:\\.[0-9]+)?)|(?:\\.[0-9]+))
-          ((?:px|pt|ch|cm|mm|in|r?em|ex|pc|deg|g?rad|dpi|dpcm|dppx|fr|ms|s|turn|vh|vmax|vmin|vw)\\b|%)?
+          ((?:px|pt|ch|cm|mm|in|r?em|ex|pc|deg|g?rad|dpi|dpcm|dppx|fr|ms|s|turn|vh|vmax|vmin|vw|k?[hH]z)\\b|%)?
           '
         'name': 'constant.numeric.css'
       }


### PR DESCRIPTION
CSS units are typically presented in lowercase, but the Hz and kHz units are presented with a capital H in nearly every resource I've seen online.

Here are some major examples:

- http://www.w3.org/TR/css3-values/
- https://developer.mozilla.org/en-US/docs/Web/CSS/frequency
- https://en.wikipedia.org/wiki/Comparison_of_layout_engines_(Cascading_Style_Sheets)

Anyone who copies and pastes from online resources will expect their units to be properly highlighted by Atom, so the syntax pattern recognizes both H and h.  This is in contrast to all other units, which are only recognized if written in the conventional lowercase.