### PR TITLE
Added support for inline block comment

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -468,6 +468,9 @@
         'name': 'meta.property-value.css'
         'patterns': [
           {
+            'include': '#comment-block'
+          }
+          {
             'include': '#property-values'
           }
         ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "language-css",
   "description": "CSS support in Atom",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "engines": {
     "atom": "*",
     "node": "*"

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -180,8 +180,7 @@ describe 'CSS grammar', ->
       expect(tokens[11]).toEqual value: '*/', scopes: ['source.css', 'meta.at-rule.media.css', 'comment.block.css', 'punctuation.definition.comment.css']
       expect(tokens[12]).toEqual value: ')', scopes: ['source.css', 'meta.at-rule.media.css']
 
-  describe 'inline comments', ->
-    it 'on same line', ->
+    it 'tokenizes inline comments on same line', ->
       {tokens} = grammar.tokenizeLine 'section {border:4px/*padding:1px*/}'
 
       expect(tokens[0]).toEqual value: 'section', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.css']
@@ -196,7 +195,7 @@ describe 'CSS grammar', ->
       expect(tokens[9]).toEqual value: '*/', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'comment.block.css', 'punctuation.definition.comment.css']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'punctuation.section.property-list.end.css']
 
-    it 'on multi-line', ->
+    it 'tokenizes inline comments on multi-line', ->
       lines = grammar.tokenizeLines """
         section {
           border:4px /*1px;

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -179,3 +179,25 @@ describe 'CSS grammar', ->
       expect(tokens[10]).toEqual value: ' comment ', scopes: ['source.css', 'meta.at-rule.media.css', 'comment.block.css']
       expect(tokens[11]).toEqual value: '*/', scopes: ['source.css', 'meta.at-rule.media.css', 'comment.block.css', 'punctuation.definition.comment.css']
       expect(tokens[12]).toEqual value: ')', scopes: ['source.css', 'meta.at-rule.media.css']
+
+  describe 'inline comments', ->
+    it 'on same line', ->
+      {tokens} = grammar.tokenizeLine 'section {border:4px/*padding:1px*/}'
+
+      expect(tokens[7].value).toBe '/*'
+      expect(tokens[7].scopes).toContain 'comment.block.css'
+      expect(tokens[8]).toEqual value: 'padding:1px', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'comment.block.css']
+      expect(tokens[9].value).toBe '*/'
+      expect(tokens[9].scopes).toContain 'comment.block.css'
+
+    it 'on mulit-line', ->
+      lines = grammar.tokenizeLines """
+        section {
+          border:4px /*1px;
+          padding:1px*/
+      }
+      """
+
+      expect(lines[1][7]).toEqual value: '1px;', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'comment.block.css']
+      expect(lines[2][0].scopes).toContain 'comment.block.css'
+      expect(lines[2][1].scopes).toContain 'comment.block.css'


### PR DESCRIPTION
fixed an issue with this grammar not supporting block-comments after unterminated property values