### PR TITLE
Fix custom element selectors

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -487,11 +487,11 @@
     'name': 'meta.selector.css'
     'patterns': [
       {
-        'match': '\\b(a|abbr|acronym|address|area|article|aside|audio|b|base|bdi|bdo|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|keygen|label|legend|li|link|main|map|mark|math|menu|menuitem|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rb|rp|rt|rtc|ruby|s|samp|script|section|select|small|source|span|strike|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr)\\b'
+        'match': '\\b(a|abbr|acronym|address|area|article|aside|audio|b|base|bdi|bdo|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|keygen|label|legend|li|link|main|map|mark|math|menu|menuitem|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rb|rp|rt|rtc|ruby|s|samp|script|section|select|small|source|span|strike|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr)\\b(?=\\.|\\s++[^:]|\\s*[,{]|(::?)[a-z]+|\\[[a-z-\\(\\)]+\\])'
         'name': 'entity.name.tag.css'
       }
       {
-        'match': '\\b([a-zA-Z0-9]+(-[a-zA-Z0-9]+)+)(?=\\.|\\s++[^:]|\\s*[,{]|:(link|visited|hover|active|focus|target|lang|disabled|enabled|checked|indeterminate|root|nth-child()|nth-last-child()|nth-of-type()|nth-last-of-type()|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|not|valid|invalid|:shadow)(\\([0-9A-Za-z]*\\))?)'
+        'match': '\\b([a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)\\b(?=\\.|\\s++[^:]|\\s*[,{]|(::?)[a-z]+|\\[[a-z-\\(\\)]+\\])'
         'name': 'entity.name.tag.custom.css'
       }
       {
@@ -516,7 +516,7 @@
         'captures':
           '1':
             'name': 'punctuation.definition.entity.css'
-        'match': '(:+)(after|before|content|first-letter|first-line|host|(-(moz|webkit|ms)-)?selection)\\b'
+        'match': '(::?)(after|before|content|first-letter|first-line|host|(-(moz|webkit|ms)-)?selection)\\b'
         'name': 'entity.other.attribute-name.pseudo-element.css'
       }
       {

--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -483,7 +483,7 @@
     ]
   'selector':
     'begin': '\\s*(?=[\\[:.*#a-zA-Z])'
-    'end': '(?=[/@{)])'
+    'end': '(?=[\\/@{\\)])'
     'name': 'meta.selector.css'
     'patterns': [
       {


### PR DESCRIPTION
I fixed some simple custom tag matching regexes. Now they work better with [] and :: after it. Also added some escaping on line 486 for clarity, and stopped matching more than 2 :'s on line 519.

<img width="210" alt="captura de pantalla 2016-07-08 a las 2 51 51" src="https://cloud.githubusercontent.com/assets/5406212/16674310/0afe6b16-44b7-11e6-94fb-79752d358530.png">
<img width="235" alt="captura de pantalla 2016-07-08 a las 2 50 42" src="https://cloud.githubusercontent.com/assets/5406212/16674313/0e150058-44b7-11e6-8a3f-a5656494b689.png">
