### PR TITLE
Fix custom element selectors

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -487,11 +487,11 @@
     'name': 'meta.selector.css'
     'patterns': [
       {
-        'match': '\\b(a|abbr|acronym|address|area|article|aside|audio|b|base|bdi|bdo|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|keygen|label|legend|li|link|main|map|mark|math|menu|menuitem|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rb|rp|rt|rtc|ruby|s|samp|script|section|select|small|source|span|strike|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr)\\b(?=\\.|\\s++[^:]|\\s*[,{]|(::?)[a-z]+|\\[[a-z-\\(\\)]+\\])'
+        'match': '\\b(?<=\\s|^|,)(?<![\\.\\:\\)\\]])(a|abbr|acronym|address|area|article|aside|audio|b|base|bdi|bdo|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|keygen|label|legend|li|link|main|map|mark|math|menu|menuitem|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rb|rp|rt|rtc|ruby|s|samp|script|section|select|small|source|span|strike|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr)\\b(?=(?:\\.[a-z-]+|::?[a-z-]+(\\(.*\\))?|\\[.+\\])*\\s*\\{)'
         'name': 'entity.name.tag.css'
       }
       {
-        'match': '\\b([a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)\\b(?=\\.|\\s++[^:]|\\s*[,{]|(::?)[a-z]+|\\[[a-z-\\(\\)]+\\])'
+        'match': '\\b(?<=\\s|^|,)(?<![\\.\\:\\)\\]])([a-zA-Z0-9-]*)\\b(?=(?:\\.[a-z-]+|::?[a-z-]+(\\(.*\\))?|\\[.+\\])*\\s*\\{)'
         'name': 'entity.name.tag.custom.css'
       }
       {

--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -487,11 +487,11 @@
     'name': 'meta.selector.css'
     'patterns': [
       {
-        'match': '\\b(?<=\\s|^|,)(?<![\\.\\:\\)\\]-])(a|abbr|acronym|address|area|article|aside|audio|b|base|bdi|bdo|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|keygen|label|legend|li|link|main|map|mark|math|menu|menuitem|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rb|rp|rt|rtc|ruby|s|samp|script|section|select|small|source|span|strike|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr)\\b(?=(?:\\.[a-z-]+|::?[a-z-]+(\\(.*\\))?|\\[.+\\])*\\s*\\{)'
+        'match': '\\b(?<=\\s|^|,)(?<![\\.\\:\\)\\]-])(a|abbr|acronym|address|area|article|aside|audio|b|base|bdi|bdo|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|keygen|label|legend|li|link|main|map|mark|math|menu|menuitem|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rb|rp|rt|rtc|ruby|s|samp|script|section|select|small|source|span|strike|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr)\\b(?=(?:\\.[a-z-]+|::?[a-z-]+(\\(.*\\))?|\\[.+\\])*\\s*({|,|\\s*(?=[\\[:.*#a-zA-Z])))'
         'name': 'entity.name.tag.css'
       }
       {
-        'match': '\\b(?<=\\s|^|,)(?<![\\.\\:\\)\\]-])([a-zA-Z0-9-]*)\\b(?=(?:\\.[a-z-]+|::?[a-z-]+(\\(.*\\))?|\\[.+\\])*\\s*\\{)'
+        'match': '\\b(?<=\\s|^|,)(?<![\\.\\:\\)\\]-])([a-zA-Z0-9-]*)\\b(?=(?:\\.[a-z-]+|::?[a-z-]+(\\(.*\\))?|\\[.+\\])*\\s*({|,|\\s*(?=[\\[:.*#a-zA-Z])))'
         'name': 'entity.name.tag.custom.css'
       }
       {

--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -487,11 +487,11 @@
     'name': 'meta.selector.css'
     'patterns': [
       {
-        'match': '\\b(a|abbr|acronym|address|area|article|aside|audio|b|base|bdi|bdo|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|keygen|label|legend|li|link|main|map|mark|math|menu|menuitem|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rb|rp|rt|rtc|ruby|s|samp|script|section|select|small|source|span|strike|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr)\\b'
+        'match': '\\b(a|abbr|acronym|address|area|article|aside|audio|b|base|bdi|bdo|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|keygen|label|legend|li|link|main|map|mark|math|menu|menuitem|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rb|rp|rt|rtc|ruby|s|samp|script|section|select|small|source|span|strike|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr)\\b(?=\\.|\\s++[^:]|\\s*[,{]|(::?)[a-z]+|\\[[a-z-\\(\\)]+\\])'
         'name': 'entity.name.tag.css'
       }
       {
-        'match': '\\b([a-zA-Z0-9]+(-[a-zA-Z0-9]+)+)(?=\\.|\\s++[^:]|\\s*[,{]|:(link|visited|hover|active|focus|target|lang|disabled|enabled|checked|indeterminate|root|nth-child()|nth-last-child()|nth-of-type()|nth-last-of-type()|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|not|valid|invalid|:shadow)(\\([0-9A-Za-z]*\\))?)'
+        'match': '\\b([a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)\\b(?=\\.|\\s++[^:]|\\s*[,{]|(::?)[a-z]+|\\[[a-z-\\(\\)]+\\])'
         'name': 'entity.name.tag.custom.css'
       }
       {
@@ -516,7 +516,7 @@
         'captures':
           '1':
             'name': 'punctuation.definition.entity.css'
-        'match': '(:+)(after|before|content|first-letter|first-line|host|(-(moz|webkit|ms)-)?selection)\\b'
+        'match': '(::?)(after|before|content|first-letter|first-line|host|(-(moz|webkit|ms)-)?selection)\\b'
         'name': 'entity.other.attribute-name.pseudo-element.css'
       }
       {

--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -483,7 +483,7 @@
     ]
   'selector':
     'begin': '\\s*(?=[\\[:.*#a-zA-Z])'
-    'end': '(?=[/@{)])'
+    'end': '(?=[\\/@{\\)])'
     'name': 'meta.selector.css'
     'patterns': [
       {

--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -487,11 +487,11 @@
     'name': 'meta.selector.css'
     'patterns': [
       {
-        'match': '\\b(?<=\\s|^|,)(?<![\\.\\:\\)\\]])(a|abbr|acronym|address|area|article|aside|audio|b|base|bdi|bdo|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|keygen|label|legend|li|link|main|map|mark|math|menu|menuitem|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rb|rp|rt|rtc|ruby|s|samp|script|section|select|small|source|span|strike|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr)\\b(?=(?:\\.[a-z-]+|::?[a-z-]+(\\(.*\\))?|\\[.+\\])*\\s*\\{)'
+        'match': '\\b(?<=\\s|^|,)(?<![\\.\\:\\)\\]-])(a|abbr|acronym|address|area|article|aside|audio|b|base|bdi|bdo|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|keygen|label|legend|li|link|main|map|mark|math|menu|menuitem|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rb|rp|rt|rtc|ruby|s|samp|script|section|select|small|source|span|strike|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr)\\b(?=(?:\\.[a-z-]+|::?[a-z-]+(\\(.*\\))?|\\[.+\\])*\\s*\\{)'
         'name': 'entity.name.tag.css'
       }
       {
-        'match': '\\b(?<=\\s|^|,)(?<![\\.\\:\\)\\]])([a-zA-Z0-9-]*)\\b(?=(?:\\.[a-z-]+|::?[a-z-]+(\\(.*\\))?|\\[.+\\])*\\s*\\{)'
+        'match': '\\b(?<=\\s|^|,)(?<![\\.\\:\\)\\]-])([a-zA-Z0-9-]*)\\b(?=(?:\\.[a-z-]+|::?[a-z-]+(\\(.*\\))?|\\[.+\\])*\\s*\\{)'
         'name': 'entity.name.tag.custom.css'
       }
       {

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -37,7 +37,7 @@ describe 'CSS grammar', ->
       expect(tokens[11]).toEqual value: '}', scopes: ["source.css", "meta.property-list.css", "punctuation.section.property-list.end.css"]
 
     it 'tokenizes long selectors', ->
-      {tokens} = grammar.tokenizeLine "custom-tag[attribute^='test']:active:nth-child(n+1)::after {}"
+      {tokens} = grammar.tokenizeLine "custom-tag[attribute^='test']:active:nth-child(n+1) custom-tag, custom-tag::after {}"
 
       expect(tokens[0]).toEqual value: 'custom-tag', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.custom.css']
       expect(tokens[1]).toEqual value: '[', scopes: ['source.css', 'meta.selector.css', 'meta.attribute-selector.css', 'punctuation.definition.entity.css']
@@ -54,11 +54,15 @@ describe 'CSS grammar', ->
       expect(tokens[12]).toEqual value: '(', scopes: ['source.css', 'meta.selector.css', 'punctuation.section.function.css']
       expect(tokens[13]).toEqual value: 'n+1', scopes: ['source.css', 'meta.selector.css', 'constant.numeric.css']
       expect(tokens[14]).toEqual value: ')', scopes: ['source.css', 'meta.selector.css', 'punctuation.section.function.css']
-      expect(tokens[15]).toEqual value: '::', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css', 'punctuation.definition.entity.css']
-      expect(tokens[16]).toEqual value: 'after', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css']
-      expect(tokens[17]).toEqual value: ' ', scopes: ['source.css', 'meta.selector.css']
-      expect(tokens[18]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.css']
-      expect(tokens[19]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.end.css']
+      expect(tokens[15]).toEqual value: ' ', scopes: ['source.css', 'meta.selector.css']
+      expect(tokens[16]).toEqual value: 'custom-tag', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.custom.css']
+      expect(tokens[17]).toEqual value: ', ', scopes: ['source.css', 'meta.selector.css']
+      expect(tokens[18]).toEqual value: 'custom-tag', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.custom.css']
+      expect(tokens[19]).toEqual value: '::', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css', 'punctuation.definition.entity.css']
+      expect(tokens[20]).toEqual value: 'after', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css']
+      expect(tokens[21]).toEqual value: ' ', scopes: ['source.css', 'meta.selector.css']
+      expect(tokens[22]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.css']
+      expect(tokens[23]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.end.css']
 
     it 'tokenizes correct numeric values', ->
       {tokens} = grammar.tokenizeLine 'div { font-size: 14px; }'

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -22,7 +22,7 @@ describe 'CSS grammar', ->
 
     # Needs more complex examples
     it 'tokenizes complex selectors', ->
-      {tokens} = grammar.tokenizeLine '[disabled], [disabled] + p'
+      {tokens} = grammar.tokenizeLine '[disabled], [disabled] + p {}'
       expect(tokens[0]).toEqual value: '[', scopes: ["source.css", "meta.selector.css", "meta.attribute-selector.css", "punctuation.definition.entity.css"]
       expect(tokens[1]).toEqual value: 'disabled', scopes: ["source.css", "meta.selector.css", "meta.attribute-selector.css", "entity.other.attribute-name.attribute.css"]
       expect(tokens[2]).toEqual value: ']', scopes: ["source.css", "meta.selector.css", "meta.attribute-selector.css", "punctuation.definition.entity.css"]
@@ -32,6 +32,9 @@ describe 'CSS grammar', ->
       expect(tokens[6]).toEqual value: ']', scopes: ["source.css", "meta.selector.css", "meta.attribute-selector.css", "punctuation.definition.entity.css"]
       expect(tokens[7]).toEqual value: ' + ', scopes: ["source.css", "meta.selector.css"]
       expect(tokens[8]).toEqual value: 'p', scopes: ["source.css", "meta.selector.css", "entity.name.tag.css"]
+      expect(tokens[9]).toEqual value: ' ', scopes: ["source.css", "meta.selector.css"]
+      expect(tokens[10]).toEqual value: '{', scopes: ["source.css", "meta.property-list.css", "punctuation.section.property-list.begin.css"]
+      expect(tokens[11]).toEqual value: '}', scopes: ["source.css", "meta.property-list.css", "punctuation.section.property-list.end.css"]
 
     it 'tokenizes correct numeric values', ->
       {tokens} = grammar.tokenizeLine 'div { font-size: 14px; }'

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -36,6 +36,30 @@ describe 'CSS grammar', ->
       expect(tokens[10]).toEqual value: '{', scopes: ["source.css", "meta.property-list.css", "punctuation.section.property-list.begin.css"]
       expect(tokens[11]).toEqual value: '}', scopes: ["source.css", "meta.property-list.css", "punctuation.section.property-list.end.css"]
 
+    it 'tokenizes long selectors', ->
+      {tokens} = grammar.tokenizeLine "custom-tag[attribute^='test']:active:nth-child(n+1)::after {}"
+
+      expect(tokens[0]).toEqual value: 'custom-tag', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.custom.css']
+      expect(tokens[1]).toEqual value: '[', scopes: ['source.css', 'meta.selector.css', 'meta.attribute-selector.css', 'punctuation.definition.entity.css']
+      expect(tokens[2]).toEqual value: 'attribute', scopes: ['source.css', 'meta.selector.css', 'meta.attribute-selector.css', 'entity.other.attribute-name.attribute.css']
+      expect(tokens[3]).toEqual value: '^=', scopes: ['source.css', 'meta.selector.css', 'meta.attribute-selector.css', 'punctuation.separator.operator.css']
+      expect(tokens[4]).toEqual value: '\'', scopes: ['source.css', 'meta.selector.css', 'meta.attribute-selector.css', 'string.quoted.double.attribute-value.css', 'punctuation.definition.string.begin.css']
+      expect(tokens[5]).toEqual value: 'test', scopes: ['source.css', 'meta.selector.css', 'meta.attribute-selector.css', 'string.quoted.double.attribute-value.css']
+      expect(tokens[6]).toEqual value: '\'', scopes: ['source.css', 'meta.selector.css', 'meta.attribute-selector.css', 'string.quoted.double.attribute-value.css', 'punctuation.definition.string.end.css']
+      expect(tokens[7]).toEqual value: ']', scopes: ['source.css', 'meta.selector.css', 'meta.attribute-selector.css', 'punctuation.definition.entity.css']
+      expect(tokens[8]).toEqual value: ':', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
+      expect(tokens[9]).toEqual value: 'active', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css']
+      expect(tokens[10]).toEqual value: ':', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
+      expect(tokens[11]).toEqual value: 'nth-child', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css']
+      expect(tokens[12]).toEqual value: '(', scopes: ['source.css', 'meta.selector.css', 'punctuation.section.function.css']
+      expect(tokens[13]).toEqual value: 'n+1', scopes: ['source.css', 'meta.selector.css', 'constant.numeric.css']
+      expect(tokens[14]).toEqual value: ')', scopes: ['source.css', 'meta.selector.css', 'punctuation.section.function.css']
+      expect(tokens[15]).toEqual value: '::', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css', 'punctuation.definition.entity.css']
+      expect(tokens[16]).toEqual value: 'after', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css']
+      expect(tokens[17]).toEqual value: ' ', scopes: ['source.css', 'meta.selector.css']
+      expect(tokens[18]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.css']
+      expect(tokens[19]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.end.css']
+
     it 'tokenizes correct numeric values', ->
       {tokens} = grammar.tokenizeLine 'div { font-size: 14px; }'
       expect(tokens[7]).toEqual value: '14', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'constant.numeric.css']


### PR DESCRIPTION
I fixed some tokening problems for custom tags, the regexes now look for a {, a space, or the begin of another element. Now they work better with [] and :: after them. Also added some escaping on line 486 for clarity, and stopped matching more than 2 :'s on line 519. Added a test, and changed one because it did not have a {.

<img width="210" alt="captura de pantalla 2016-07-08 a las 2 51 51" src="https://cloud.githubusercontent.com/assets/5406212/16674310/0afe6b16-44b7-11e6-94fb-79752d358530.png">
<img width="235" alt="captura de pantalla 2016-07-08 a las 2 50 42" src="https://cloud.githubusercontent.com/assets/5406212/16674313/0e150058-44b7-11e6-8a3f-a5656494b689.png">
