### PR TITLE
Fix #24

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -282,7 +282,12 @@
         'beginCaptures':
           '1':
             'name': 'keyword.operator.logic.media.css'
+          '2':
+            'name': 'punctuation.definition.media.feature.begin.css'
         'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.media.feature.end.css'
         'patterns': [
           {
             'begin': '(?x)\n\t                            (\n\t                                ((min|max)-)?\n\t                                (\n\t                                    ((device-)?(height|width|aspect-ratio))|\n\t                                    (color(-index)?)|monochrome|resolution\n\t                                )\n\t                            )|grid|scan|orientation\n\t                            \\s*(?=[:)])'

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -170,7 +170,7 @@ describe 'CSS grammar', ->
 
       expect(tokens[0]).toEqual value: '@', scopes: ['source.css', 'meta.at-rule.media.css', 'keyword.control.at-rule.media.css', 'punctuation.definition.keyword.css']
       expect(tokens[1]).toEqual value: 'media', scopes: ['source.css', 'meta.at-rule.media.css', 'keyword.control.at-rule.media.css']
-      expect(tokens[3]).toEqual value: '(', scopes: ['source.css', 'meta.at-rule.media.css']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.css', 'meta.at-rule.media.css', 'punctuation.definition.media.feature.begin.css']
       expect(tokens[4]).toEqual value: 'max-height', scopes: ['source.css', 'meta.at-rule.media.css', 'support.type.property-name.media.css']
       expect(tokens[5]).toEqual value: ':', scopes: ['source.css', 'meta.at-rule.media.css', 'punctuation.separator.key-value.css']
       expect(tokens[7]).toEqual value: '40', scopes: ['source.css', 'meta.at-rule.media.css', 'constant.numeric.css']
@@ -178,7 +178,7 @@ describe 'CSS grammar', ->
       expect(tokens[9]).toEqual value: '/*', scopes: ['source.css', 'meta.at-rule.media.css', 'comment.block.css', 'punctuation.definition.comment.css']
       expect(tokens[10]).toEqual value: ' comment ', scopes: ['source.css', 'meta.at-rule.media.css', 'comment.block.css']
       expect(tokens[11]).toEqual value: '*/', scopes: ['source.css', 'meta.at-rule.media.css', 'comment.block.css', 'punctuation.definition.comment.css']
-      expect(tokens[12]).toEqual value: ')', scopes: ['source.css', 'meta.at-rule.media.css']
+      expect(tokens[12]).toEqual value: ')', scopes: ['source.css', 'meta.at-rule.media.css', 'punctuation.definition.media.feature.end.css']
 
     it 'tokenizes inline comments on same line', ->
       {tokens} = grammar.tokenizeLine 'section {border:4px/*padding:1px*/}'


### PR DESCRIPTION
Fixes issue #24, don't know if the names 'punctuation.definition.media.feature.begin.css' and 'punctuation.definition.media.feature.end.css' are good but they seemed logical.
