### PR TITLE
Improve the support for :lang()

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -592,6 +592,30 @@
         'name': 'entity.other.attribute-name.pseudo-element.css'
       }
       {
+        'captures':
+          '1':
+            'name': 'entity.other.attribute-name.pseudo-class.css'
+          '2':
+            'name': 'punctuation.definition.entity.css'
+          '3':
+            'name': 'punctuation.section.function.css'
+          '4':
+            'name': 'meta.language-ranges.css'
+            'patterns': [
+              {
+                'match': '[a-zA-Z\\*]+(\\-[a-zA-Z\\*]+)*'
+                'name': 'support.constant.language-range.css'
+              }
+              {
+                'match': ','
+                'name': 'punctuation.separator.css'
+              }
+            ]
+          '5':
+            'name': 'punctuation.section.function.css'
+        'match': '((:)lang)(\\()(.*?)(\\))'
+      }
+      {
         'begin': '((:)not)(\\()'
         'beginCaptures':
           '1':
@@ -623,30 +647,6 @@
           '5':
             'name': 'punctuation.section.function.css'
         'match': '((:)nth-(?:(?:last-)?child|(?:last-)?of-type))(\\()(\\-?(?:\\d+n?|n)(?:\\+\\d+)?|even|odd)(\\))'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'entity.other.attribute-name.pseudo-class.css'
-          '2':
-            'name': 'punctuation.definition.entity.css'
-          '3':
-            'name': 'punctuation.section.function.css'
-          '4':
-            'name': 'meta.language-ranges.css'
-            'patterns': [
-              {
-                'match': '[a-zA-Z\\*]+(\\-[a-zA-Z\\*]+)*'
-                'name': 'support.constant.language-range.css'
-              }
-              {
-                'match': ','
-                'name': 'punctuation.separator.css'
-              }
-            ]
-          '5':
-            'name': 'punctuation.section.function.css'
-        'match': '((:)lang)(\\()(.*?)(\\))'
       }
       {
         'captures':

--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -561,6 +561,20 @@
         'captures':
           '1':
             'name': 'punctuation.definition.entity.css'
+        'match': '''(?x)
+          (:)
+          (
+            active|hover|link|visited|focus
+          | (first|last|only)-child|(first|last|only)-of-type|empty|root|target|first|left|right|host
+          | checked|enabled|default|disabled|in-range|indeterminate|invalid|optional|out-of-range|read-only|read-write|required|valid
+          )(?![\\w-])
+        '''
+        'name': 'entity.other.attribute-name.pseudo-class.css'
+      }
+      {
+        'captures':
+          '1':
+            'name': 'punctuation.definition.entity.css'
           '2':
             'name': 'punctuation.definition.entity.css'
         'match': '''(?x)
@@ -571,20 +585,6 @@
           (?![\\w-])
         '''
         'name': 'entity.other.attribute-name.pseudo-element.css'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.entity.css'
-        'match': '(:)((first|last|only)-child|(first|last|only)-of-type|empty|root|target|first|left|right|host)\\b'
-        'name': 'entity.other.attribute-name.pseudo-class.css'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.entity.css'
-        'match': '(:)(checked|enabled|default|disabled|in-range|indeterminate|invalid|optional|out-of-range|read-only|read-write|required|valid)\\b'
-        'name': 'entity.other.attribute-name.pseudo-class.ui-state.css'
       }
       {
         'begin': '((:)not)(\\()'
@@ -642,13 +642,6 @@
           '5':
             'name': 'punctuation.section.function.css'
         'match': '((:)lang)(\\()(.*?)(\\))'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.entity.css'
-        'match': '(:)(active|hover|link|visited|focus)\\b'
-        'name': 'entity.other.attribute-name.pseudo-class.css'
       }
       {
         'captures':

--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -600,7 +600,6 @@
             'name': 'punctuation.definition.entity.css'
           '3':
             'name': 'punctuation.section.function.css'
-        'contentName': 'meta.language-ranges.css'
         'end': '\\)'
         'endCaptures':
           '0':

--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -607,8 +607,42 @@
             'name': 'punctuation.section.function.css'
         'patterns': [
           {
-            'match': '[a-zA-Z\\*]+(\\-[a-zA-Z\\*]+)*'
+            'match': '(?<=[(,\\s])[a-zA-Z]+(-[a-zA-Z0-9]*+)*+(?=[),\\s])'
             'name': 'support.constant.language-range.css'
+          }
+          {
+            'begin': '"'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.string.begin.css'
+            'end': '"'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.definition.string.end.css'
+            'name': 'string.quoted.double.css'
+            'patterns': [
+              {
+                'match': '(?<=["\\s])[a-zA-Z*]+(-[a-zA-Z0-9*]*+)*+(?=["\\s])'
+                'name': 'support.constant.language-range.css'
+              }
+            ]
+          }
+          {
+            'begin': "'"
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.string.begin.css'
+            'end': "'"
+            'endCaptures':
+              '0':
+                'name': 'punctuation.definition.string.end.css'
+            'name': 'string.quoted.single.css'
+            'patterns': [
+              {
+                'match': "(?<=['\\s])[a-zA-Z*]+(-[a-zA-Z0-9*]*+)*+(?=['\\s])"
+                'name': 'support.constant.language-range.css'
+              }
+            ]
           }
           {
             'match': ','

--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -592,28 +592,29 @@
         'name': 'entity.other.attribute-name.pseudo-element.css'
       }
       {
-        'captures':
+        'begin': '((:)lang)(\\()'
+        'beginCaptures':
           '1':
             'name': 'entity.other.attribute-name.pseudo-class.css'
           '2':
             'name': 'punctuation.definition.entity.css'
           '3':
             'name': 'punctuation.section.function.css'
-          '4':
-            'name': 'meta.language-ranges.css'
-            'patterns': [
-              {
-                'match': '[a-zA-Z\\*]+(\\-[a-zA-Z\\*]+)*'
-                'name': 'support.constant.language-range.css'
-              }
-              {
-                'match': ','
-                'name': 'punctuation.separator.css'
-              }
-            ]
-          '5':
+        'contentName': 'meta.language-ranges.css'
+        'end': '\\)'
+        'endCaptures':
+          '0':
             'name': 'punctuation.section.function.css'
-        'match': '((:)lang)(\\()(.*?)(\\))'
+        'patterns': [
+          {
+            'match': '[a-zA-Z\\*]+(\\-[a-zA-Z\\*]+)*'
+            'name': 'support.constant.language-range.css'
+          }
+          {
+            'match': ','
+            'name': 'punctuation.separator.css'
+          }
+        ]
       }
       {
         'begin': '((:)not)(\\()'

--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -564,9 +564,14 @@
         'match': '''(?x)
           (:)
           (
-            active|hover|link|visited|focus
-          | (first|last|only)-child|(first|last|only)-of-type|empty|root|target|first|left|right|host
-          | checked|enabled|default|disabled|in-range|indeterminate|invalid|optional|out-of-range|read-only|read-write|required|valid
+            link|target|visited                                     # location
+          | active|focus|hover                                      # user action
+          | default|disabled|enabled|read-only|read-write           # input control state
+          | checked|indeterminate                                   # input value state
+          | in-range|invalid|optional|out-of-range|required|valid   # input value-checking
+          | empty|(first|last|only)-(child|of-type)|root            # tree-structural
+          | first|left|right                                        # @page
+          | host                                                    # shadow DOM
           )(?![\\w-])
         '''
         'name': 'entity.other.attribute-name.pseudo-class.css'

--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -566,7 +566,7 @@
         'match': '''(?x)
           (?:
             (::?+)(?:after|before|first-letter|first-line|(?:-(?:webkit|moz|ms)-)[a-z-]++)
-          | (::)(?:backdrop|content|placeholder|selection)
+          | (::)(?:backdrop|content|placeholder|selection|shadow)
           )
           (?![\\w-])
         '''
@@ -648,13 +648,6 @@
           '1':
             'name': 'punctuation.definition.entity.css'
         'match': '(:)(active|hover|link|visited|focus)\\b'
-        'name': 'entity.other.attribute-name.pseudo-class.css'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.entity.css'
-        'match': '(::)(shadow)\\b'
         'name': 'entity.other.attribute-name.pseudo-class.css'
       }
       {

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -21,18 +21,6 @@ describe 'CSS grammar', ->
       {tokens} = grammar.tokenizeLine '*'
       expect(tokens[0]).toEqual value: '*', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.wildcard.css']
 
-    it 'tokenizes :lang() pseudo class', ->
-      {tokens} = grammar.tokenizeLine ':lang(ja,zh-Hans-CN,*-CH)'
-      expect(tokens[0]).toEqual value: ':', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
-      expect(tokens[1]).toEqual value: 'lang', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css']
-      expect(tokens[2]).toEqual value: '(', scopes: ['source.css', 'meta.selector.css', 'punctuation.section.function.css']
-      expect(tokens[3]).toEqual value: 'ja', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'support.constant.language-range.css']
-      expect(tokens[4]).toEqual value: ',', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'punctuation.separator.css']
-      expect(tokens[5]).toEqual value: 'zh-Hans-CN', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'support.constant.language-range.css']
-      expect(tokens[6]).toEqual value: ',', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'punctuation.separator.css']
-      expect(tokens[7]).toEqual value: '*-CH', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'support.constant.language-range.css']
-      expect(tokens[8]).toEqual value: ')', scopes: ['source.css', 'meta.selector.css', 'punctuation.section.function.css']
-
     # Needs more complex examples
     it 'tokenizes complex selectors', ->
       {tokens} = grammar.tokenizeLine '[disabled], [disabled] + p'
@@ -136,6 +124,25 @@ describe 'CSS grammar', ->
       it 'does not tokenize a hash token consisting of one hyphen', ->
         {tokens} = grammar.tokenizeLine '#-'
         expect(tokens[0]).toEqual value: '#-', scopes: ['source.css', 'meta.selector.css']
+
+    describe 'pseudo-classes', ->
+      it 'tokenizes regular pseudo-classes', ->
+        {tokens} = grammar.tokenizeLine 'p:first-child'
+        expect(tokens[0]).toEqual value: 'p', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.css']
+        expect(tokens[1]).toEqual value: ':', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
+        expect(tokens[2]).toEqual value: 'first-child', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css']
+
+      it 'tokenizes :lang()', ->
+        {tokens} = grammar.tokenizeLine ':lang(ja,zh-Hans-CN,*-CH)'
+        expect(tokens[0]).toEqual value: ':', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
+        expect(tokens[1]).toEqual value: 'lang', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css']
+        expect(tokens[2]).toEqual value: '(', scopes: ['source.css', 'meta.selector.css', 'punctuation.section.function.css']
+        expect(tokens[3]).toEqual value: 'ja', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'support.constant.language-range.css']
+        expect(tokens[4]).toEqual value: ',', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'punctuation.separator.css']
+        expect(tokens[5]).toEqual value: 'zh-Hans-CN', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'support.constant.language-range.css']
+        expect(tokens[6]).toEqual value: ',', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'punctuation.separator.css']
+        expect(tokens[7]).toEqual value: '*-CH', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'support.constant.language-range.css']
+        expect(tokens[8]).toEqual value: ')', scopes: ['source.css', 'meta.selector.css', 'punctuation.section.function.css']
 
     describe 'pseudo-elements', ->
       # :first-line, :first-letter, :before and :after

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -184,8 +184,8 @@ describe 'CSS grammar', ->
       it 'tokenizes the combination of type selectors followed by pseudo-elements', ->
         {tokens} = grammar.tokenizeLine 'very-custom::shadow'
         expect(tokens[0]).toEqual value: 'very-custom', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.custom.css']
-        expect(tokens[1]).toEqual value: '::', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
-        expect(tokens[2]).toEqual value: 'shadow', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css']
+        expect(tokens[1]).toEqual value: '::', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css', 'punctuation.definition.entity.css']
+        expect(tokens[2]).toEqual value: 'shadow', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css']
 
   describe 'property lists (declaration blocks)', ->
     it 'tokenizes inline property lists', ->

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -138,24 +138,24 @@ describe 'CSS grammar', ->
           expect(tokens[0]).toEqual value: ':', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
           expect(tokens[1]).toEqual value: 'lang', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css']
           expect(tokens[2]).toEqual value: '(', scopes: ['source.css', 'meta.selector.css', 'punctuation.section.function.css']
-          expect(tokens[3]).toEqual value: 'zh-Hans-CN', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'support.constant.language-range.css']
-          expect(tokens[4]).toEqual value: ',', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'punctuation.separator.css']
-          expect(tokens[5]).toEqual value: 'es-419', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'support.constant.language-range.css']
+          expect(tokens[3]).toEqual value: 'zh-Hans-CN', scopes: ['source.css', 'meta.selector.css', 'support.constant.language-range.css']
+          expect(tokens[4]).toEqual value: ',', scopes: ['source.css', 'meta.selector.css', 'punctuation.separator.css']
+          expect(tokens[5]).toEqual value: 'es-419', scopes: ['source.css', 'meta.selector.css', 'support.constant.language-range.css']
           expect(tokens[6]).toEqual value: ')', scopes: ['source.css', 'meta.selector.css', 'punctuation.section.function.css']
 
         it 'does not tokenize unquoted language ranges containing asterisks', ->
           {tokens} = grammar.tokenizeLine ':lang(zh-*-CN)'
-          expect(tokens[3]).toEqual value: 'zh-*-CN', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css']
+          expect(tokens[3]).toEqual value: 'zh-*-CN', scopes: ['source.css', 'meta.selector.css']
 
         it 'tokenizes language ranges containing asterisks quoted as strings', ->
           {tokens} = grammar.tokenizeLine ':lang("zh-*-CN",\'*-ab-\')'
-          expect(tokens[3]).toEqual value: '"', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'string.quoted.double.css', 'punctuation.definition.string.begin.css']
-          expect(tokens[4]).toEqual value: 'zh-*-CN', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'string.quoted.double.css', 'support.constant.language-range.css']
-          expect(tokens[5]).toEqual value: '"', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'string.quoted.double.css', 'punctuation.definition.string.end.css']
-          expect(tokens[6]).toEqual value: ',', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'punctuation.separator.css']
-          expect(tokens[7]).toEqual value: "'", scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'string.quoted.single.css', 'punctuation.definition.string.begin.css']
-          expect(tokens[8]).toEqual value: '*-ab-', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'string.quoted.single.css', 'support.constant.language-range.css']
-          expect(tokens[9]).toEqual value: "'", scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'string.quoted.single.css', 'punctuation.definition.string.end.css']
+          expect(tokens[3]).toEqual value: '"', scopes: ['source.css', 'meta.selector.css', 'string.quoted.double.css', 'punctuation.definition.string.begin.css']
+          expect(tokens[4]).toEqual value: 'zh-*-CN', scopes: ['source.css', 'meta.selector.css', 'string.quoted.double.css', 'support.constant.language-range.css']
+          expect(tokens[5]).toEqual value: '"', scopes: ['source.css', 'meta.selector.css', 'string.quoted.double.css', 'punctuation.definition.string.end.css']
+          expect(tokens[6]).toEqual value: ',', scopes: ['source.css', 'meta.selector.css', 'punctuation.separator.css']
+          expect(tokens[7]).toEqual value: "'", scopes: ['source.css', 'meta.selector.css', 'string.quoted.single.css', 'punctuation.definition.string.begin.css']
+          expect(tokens[8]).toEqual value: '*-ab-', scopes: ['source.css', 'meta.selector.css', 'string.quoted.single.css', 'support.constant.language-range.css']
+          expect(tokens[9]).toEqual value: "'", scopes: ['source.css', 'meta.selector.css', 'string.quoted.single.css', 'punctuation.definition.string.end.css']
 
     describe 'pseudo-elements', ->
       # :first-line, :first-letter, :before and :after

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -132,17 +132,30 @@ describe 'CSS grammar', ->
         expect(tokens[1]).toEqual value: ':', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
         expect(tokens[2]).toEqual value: 'first-child', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css']
 
-      it 'tokenizes :lang()', ->
-        {tokens} = grammar.tokenizeLine ':lang(ja,zh-Hans-CN,*-CH)'
-        expect(tokens[0]).toEqual value: ':', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
-        expect(tokens[1]).toEqual value: 'lang', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css']
-        expect(tokens[2]).toEqual value: '(', scopes: ['source.css', 'meta.selector.css', 'punctuation.section.function.css']
-        expect(tokens[3]).toEqual value: 'ja', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'support.constant.language-range.css']
-        expect(tokens[4]).toEqual value: ',', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'punctuation.separator.css']
-        expect(tokens[5]).toEqual value: 'zh-Hans-CN', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'support.constant.language-range.css']
-        expect(tokens[6]).toEqual value: ',', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'punctuation.separator.css']
-        expect(tokens[7]).toEqual value: '*-CH', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'support.constant.language-range.css']
-        expect(tokens[8]).toEqual value: ')', scopes: ['source.css', 'meta.selector.css', 'punctuation.section.function.css']
+      describe ':lang()', ->
+        it 'tokenizes :lang()', ->
+          {tokens} = grammar.tokenizeLine ':lang(zh-Hans-CN,es-419)'
+          expect(tokens[0]).toEqual value: ':', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
+          expect(tokens[1]).toEqual value: 'lang', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css']
+          expect(tokens[2]).toEqual value: '(', scopes: ['source.css', 'meta.selector.css', 'punctuation.section.function.css']
+          expect(tokens[3]).toEqual value: 'zh-Hans-CN', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'support.constant.language-range.css']
+          expect(tokens[4]).toEqual value: ',', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'punctuation.separator.css']
+          expect(tokens[5]).toEqual value: 'es-419', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'support.constant.language-range.css']
+          expect(tokens[6]).toEqual value: ')', scopes: ['source.css', 'meta.selector.css', 'punctuation.section.function.css']
+
+        it 'does not tokenize unquoted language ranges containing asterisks', ->
+          {tokens} = grammar.tokenizeLine ':lang(zh-*-CN)'
+          expect(tokens[3]).toEqual value: 'zh-*-CN', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css']
+
+        it 'tokenizes language ranges containing asterisks quoted as strings', ->
+          {tokens} = grammar.tokenizeLine ':lang("zh-*-CN",\'*-ab-\')'
+          expect(tokens[3]).toEqual value: '"', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'string.quoted.double.css', 'punctuation.definition.string.begin.css']
+          expect(tokens[4]).toEqual value: 'zh-*-CN', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'string.quoted.double.css', 'support.constant.language-range.css']
+          expect(tokens[5]).toEqual value: '"', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'string.quoted.double.css', 'punctuation.definition.string.end.css']
+          expect(tokens[6]).toEqual value: ',', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'punctuation.separator.css']
+          expect(tokens[7]).toEqual value: "'", scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'string.quoted.single.css', 'punctuation.definition.string.begin.css']
+          expect(tokens[8]).toEqual value: '*-ab-', scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'string.quoted.single.css', 'support.constant.language-range.css']
+          expect(tokens[9]).toEqual value: "'", scopes: ['source.css', 'meta.selector.css', 'meta.language-ranges.css', 'string.quoted.single.css', 'punctuation.definition.string.end.css']
 
     describe 'pseudo-elements', ->
       # :first-line, :first-letter, :before and :after


### PR DESCRIPTION
The scope "meta.language-ranges.css" seems like unnecessary complexity, is it ok to remove it?