### PR TITLE
Add support for Emacs/Vim modelines

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -4,6 +4,17 @@
   'css'
   'css.erb'
 ]
+'firstLineMatch': '''(?xi)
+  # Emacs modeline
+  -\\*-(?:\\s*(?=[^:;\\s]+\\s*-\\*-)|(?:.*?[;\\s]|(?<=-\\*-))mode\\s*:\\s*)
+    css
+  (?=[\\s;]|(?<![-*])-\\*-).*?-\\*-
+  |
+  # Vim modeline
+  (?:(?:\\s|^)vi(?:m[<=>]?\\d+|m)?|\\sex)(?=:(?=\\s*set?\\s[^\\n:]+:)|:(?!\\s*set?\\s))(?:(?:\\s|\\s*:\\s*)\\w*(?:\\s*=(?:[^\\n\\\\\\s]|\\\\.)*)?)*[\\s:](?:filetype|ft|syntax)\\s*=
+    css
+  (?=\\s|:|$)
+'''
 'patterns': [
   {
     'include': '#comment-block'


### PR DESCRIPTION
## Chapter 8 of <i>"The Neverending Story of Alhadis's modeline-related pull requests"</i>

Self-explanatory. Adds `firstLineMatch` support for Vim/Emacs modelines.