### PR TITLE
Add custom properties to autocomplete

### DIFF
--- a/settings/language-css.cson
+++ b/settings/language-css.cson
@@ -38,3 +38,10 @@
           'description': "Creates a Color from hue (0-360), saturation (0-100%), lightness (0-100%), and alpha (0-1)."
           'descriptionMoreURL': 'https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#hsla()'
         }]
+
+'.source.css .variable.css':
+  'autocomplete':
+    'symbols':
+      'variable':
+        'selector': '.variable.css'
+        'typePriority': 2


### PR DESCRIPTION
### Description of the Change

Add symbol selector for custom variables for auto-completion allowing these to be a part of the suggestions for the `.source.css .variable.css` scope.

### Applicable Issues

https://github.com/atom/autocomplete-css/issues/56
https://github.com/atom/autocomplete-plus/issues/740