### PR TITLE
Amend patterns to facilitate embedding within Less

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1566,7 +1566,7 @@
         | in-range|indeterminate|invalid|left|link|optional|out-of-range
         | read-only|read-write|required|right|root|scope|target|unresolved
         | valid|visited
-      )(?![\\w-])
+      )(?![\\w-]|\\s*[;}])
     '''
     'name': 'entity.other.attribute-name.pseudo-class.css'
   'pseudo-elements':
@@ -1599,7 +1599,7 @@
           | spelling-error
         )
       )
-      (?![\\w-])
+      (?![\\w-]|\\s*[;}])
     '''
     'name': 'entity.other.attribute-name.pseudo-element.css'
   'rule-list':

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -2041,6 +2041,15 @@ describe 'CSS grammar', ->
         expect(tokens[1]).toEqual value: ':', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
         expect(tokens[2]).toEqual value: 'first-child', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css']
 
+      it "doesn't tokenise pseudo-classes if followed by a semicolon or closed bracket", ->
+        {tokens} = grammar.tokenizeLine('p{ left:left }')
+        expect(tokens[0]).toEqual value: 'p', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.css']
+        expect(tokens[1]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.bracket.curly.css']
+        expect(tokens[3]).toEqual value: 'left', scopes: ['source.css', 'meta.property-list.css', 'meta.property-name.css', 'support.type.property-name.css']
+        expect(tokens[4]).toEqual value: ':', scopes: ['source.css', 'meta.property-list.css', 'punctuation.separator.key-value.css']
+        expect(tokens[5]).toEqual value: 'left', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.property-value.css']
+        expect(tokens[7]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.end.bracket.curly.css']
+
       describe ':dir()', ->
         it 'tokenises :dir() and its keywords', ->
           lines = grammar.tokenizeLines """


### PR DESCRIPTION
While linking the `language-css` package's keyword lists to Less, I became stuck on this spec:

~~~coffeescript
it "parses property names distinctly from property values with the same text", ->
	{tokens} = grammar.tokenizeLine("{left:left;}")
~~~

I tried finding a solution which didn't involve repeating the CSS grammar's keywords, but failed. This seems to be the cleanest answer: a CSS selector ending with a semicolon or close bracket isn't valid anyway, so this seems safe to do.

(I hope I explained this correctly..)