### PR TITLE
Fix #107: @at-rules not matched if preceded by closing brace

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -186,7 +186,7 @@
       {
         # @media
         'begin': '(?i)(?=@media(\\s|\\(|/\\*|$))'
-        'end': '(?<=})'
+        'end': '(?<=})(?!\\G)'
         'patterns': [
           {
             'begin': '(?i)\\G(@)media'
@@ -224,7 +224,7 @@
       {
         # @counter-style
         'begin': '(?i)(?=@counter-style([\\s\'"{;]|/\\*|$))'
-        'end': '(?<=})'
+        'end': '(?<=})(?!\\G)'
         'patterns': [
           {
             'begin': '(?i)\\G(@)counter-style'
@@ -287,7 +287,7 @@
       {
         # @document
         'begin': '(?i)(?=@document([\\s\'"{;]|/\\*|$))'
-        'end': '(?<=})'
+        'end': '(?<=})(?!\\G)'
         'patterns': [
           {
             'begin': '(?i)\\G(@)document'
@@ -362,7 +362,7 @@
       {
         # @keyframes
         'begin': '(?i)(?=@keyframes([\\s\'"{;]|/\\*|$))'
-        'end': '(?<=})'
+        'end': '(?<=})(?!\\G)'
         'patterns': [
           {
             'begin': '(?i)\\G(@)keyframes'
@@ -437,7 +437,7 @@
       {
         # @supports
         'begin': '(?i)(?=@supports(\\s|\\(|/\\*|$))'
-        'end': '(?<=})|(?=;)'
+        'end': '(?<=})(?!\\G)|(?=;)'
         'patterns': [
           {
             'begin': '(?i)\\G(@)supports'

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -902,6 +902,20 @@ describe 'CSS grammar', ->
           expect(tokens[18]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.bracket.curly.css']
           expect(tokens[20]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.end.bracket.curly.css']
 
+          {tokens} = grammar.tokenizeLine('h1 { }@media only screen { }h2 { }')
+          expect(tokens[0]).toEqual value: 'h1', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.css']
+          expect(tokens[2]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.bracket.curly.css']
+          expect(tokens[4]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.end.bracket.curly.css']
+          expect(tokens[5]).toEqual value: '@', scopes: ['source.css', 'meta.at-rule.media.header.css', 'keyword.control.at-rule.media.css', 'punctuation.definition.keyword.css']
+          expect(tokens[6]).toEqual value: 'media', scopes: ['source.css', 'meta.at-rule.media.header.css', 'keyword.control.at-rule.media.css']
+          expect(tokens[8]).toEqual value: 'only', scopes: ['source.css', 'meta.at-rule.media.header.css', 'keyword.operator.logical.only.media.css']
+          expect(tokens[10]).toEqual value: 'screen', scopes: ['source.css', 'meta.at-rule.media.header.css', 'support.constant.media.css']
+          expect(tokens[12]).toEqual value: '{', scopes: ['source.css', 'meta.at-rule.media.body.css', 'punctuation.section.media.begin.bracket.curly.css']
+          expect(tokens[14]).toEqual value: '}', scopes: ['source.css', 'meta.at-rule.media.body.css', 'punctuation.section.media.end.bracket.curly.css']
+          expect(tokens[15]).toEqual value: 'h2', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.css']
+          expect(tokens[17]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.bracket.curly.css']
+          expect(tokens[19]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.end.bracket.curly.css']
+
         it 'tokenises level 4 media-query syntax', ->
           lines = grammar.tokenizeLines """
             @media (min-width >= 0px)

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -887,6 +887,21 @@ describe 'CSS grammar', ->
           expect(tokens[6]).toEqual value: 'wide', scopes: ['source.css', 'meta.at-rule.media.header.css']
           expect(tokens[7]).toEqual value: ')', scopes: ['source.css', 'meta.at-rule.media.header.css', 'punctuation.definition.parameters.end.bracket.round.css']
 
+        it 'tokenises @media immediately following a closing brace', ->
+          {tokens} = grammar.tokenizeLine('h1 { }@media only screen { } h2 { }')
+          expect(tokens[0]).toEqual value: 'h1', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.css']
+          expect(tokens[2]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.bracket.curly.css']
+          expect(tokens[4]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.end.bracket.curly.css']
+          expect(tokens[5]).toEqual value: '@', scopes: ['source.css', 'meta.at-rule.media.header.css', 'keyword.control.at-rule.media.css', 'punctuation.definition.keyword.css']
+          expect(tokens[6]).toEqual value: 'media', scopes: ['source.css', 'meta.at-rule.media.header.css', 'keyword.control.at-rule.media.css']
+          expect(tokens[8]).toEqual value: 'only', scopes: ['source.css', 'meta.at-rule.media.header.css', 'keyword.operator.logical.only.media.css']
+          expect(tokens[10]).toEqual value: 'screen', scopes: ['source.css', 'meta.at-rule.media.header.css', 'support.constant.media.css']
+          expect(tokens[12]).toEqual value: '{', scopes: ['source.css', 'meta.at-rule.media.body.css', 'punctuation.section.media.begin.bracket.curly.css']
+          expect(tokens[14]).toEqual value: '}', scopes: ['source.css', 'meta.at-rule.media.body.css', 'punctuation.section.media.end.bracket.curly.css']
+          expect(tokens[16]).toEqual value: 'h2', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.css']
+          expect(tokens[18]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.bracket.curly.css']
+          expect(tokens[20]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.end.bracket.curly.css']
+
         it 'tokenises level 4 media-query syntax', ->
           lines = grammar.tokenizeLines """
             @media (min-width >= 0px)


### PR DESCRIPTION
### Description of the Change

This is a fix for something I overlooked while working on #99 - the terminating pattern for nested `@at-rules` will also stop at a `}` character which precedes the original match:

~~~css
h1 { }@media  {   } /* Not matched */
h1 { } @media {   } /* Matched */
~~~

### Alternate Designs

N/A. This is a bugfix.

### Benefits

It'll fix #107 and appease users with sloppy coding habits.

### Possible Drawbacks

N/A

### Applicable Issues

N/A
