### PR TITLE
Fix valid identifier/identified error highlighting

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1774,8 +1774,6 @@
               )*
               (?:                                    # Invalid punctuation
                 [!"'%&(*;<?@^`|\\]}]                 # - NOTE: We exempt `)` from the list of checked
-                |                                    #   symbols to avoid matching `:not(.invalid)`
-                / (?!\\*)                            # - Avoid invalidating the start of a comment
               )+
             )
             # Mark remainder of selector invalid


### PR DESCRIPTION
### Description of the Change

**Before:**
Numerous **Nuclide** users are complaining already with the invalid CSS highlighting
matching `.no-highlight/abc {` yielding an invalid highlight marker.
![screenshot 2017-04-13 18 15 09](https://cloud.githubusercontent.com/assets/264320/25029756/2c223a3a-2075-11e7-9e38-c13ba2406527.png)

**After:**
It highlights correctly:
![screenshot 2017-04-13 18 17 05](https://cloud.githubusercontent.com/assets/264320/25029782/6db82fc2-2075-11e7-9535-297de8d91014.png)

### Alternate Designs

I have no idea!