### PR TITLE
Add support for the `fr` unit

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1356,8 +1356,9 @@
             (%)                               # - Percentage
             | ( deg|grad|rad|turn             # - Angle
               | Hz|kHz                        # - Frequency
-              | ch|cm|em|ex|in|mm|mozmm|pc|   # - Length
-                pt|px|q|rem|vh|vmax|vmin|vw
+              | ch|cm|em|ex|fr|in|mm|mozmm|   # - Length
+                pc|pt|px|q|rem|vh|vmax|vmin|
+                vw
               | dpi|dpcm|dppx                 # - Resolution
               | s|ms                          # - Time
               )


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Exactly what it looks like.

### Applicable Issues

Fixes atom/language-sass#211, now that language-sass is using CSS's number patterns.