### PR TITLE
Add coloring to grid keywords

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1400,7 +1400,7 @@
           |sticky|stretch|strict|stroke|stroke-box|style|sub|subgrid|subpixel-antialiased|subtract|super|sw-resize|symbolic|table|table-caption|table-cell
           |table-column|table-column-group|table-footer-group|table-header-group|table-row|table-row-group|tabular-nums|tb|tb-rl|text|text-after-edge
           |text-before-edge|text-bottom|text-top|thick|thin|titling-caps|top|top-outside|touch|traditional|transparent|triangle|ultra-condensed|ultra-expanded
-          |under|underline|unicase|unset|uppercase|upright|use-glyph-orientation|use-script|verso|vertical|vertical-ideographic|vertical-lr|vertical-rl
+          |under|underline|unicase|unset|uppercase|upright|upleft|downright|downleft|use-glyph-orientation|use-script|verso|vertical|vertical-ideographic|vertical-lr|vertical-rl
           |vertical-text|view-box|visible|visibleFill|visiblePainted|visibleStroke|w-resize|wait|wavy|weight|whitespace|wider|words|wrap|wrap-reverse
           |x-large|x-small|xx-large|xx-small|zero|zoom-in|zoom-out)
           (?![\\w-])

--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1378,7 +1378,7 @@
           |butt|capitalize|caption|cell|center|central|char|circle|clip|clone|close-quote|closest-corner|closest-side|col-resize|collapse|color|color-burn
           |color-dodge|column|column-reverse|common-ligatures|compact|condensed|contain|content|content-box|contents|context-menu|contextual|copy|cover
           |crisp-edges|crispEdges|crosshair|cyclic|darken|dashed|decimal|default|dense|diagonal-fractions|difference|digits|disabled|disc|discretionary-ligatures
-          |distribute|distribute-all-lines|distribute-letter|distribute-space|dot|dotted|double|double-circle|e-resize|each-line|ease|ease-in
+          |distribute|distribute-all-lines|distribute-letter|distribute-space|dot|dotted|double|double-circle|downleft|downright|e-resize|each-line|ease|ease-in
           |ease-in-out|ease-out|economy|ellipse|ellipsis|embed|end|evenodd|ew-resize|exact|exclude|exclusion|expanded|extends|extra-condensed|extra-expanded
           |farthest-corner|farthest-side|fill|fill-available|fill-box|filled|fit-content|fixed|flat|flex|flex-end|flex-start|flip|forwards|freeze
           |from-image|full-width|geometricPrecision|georgian|grab|grabbing|grayscale|grid|groove|hand|hanging|hard-light|help|hidden|hide
@@ -1400,7 +1400,7 @@
           |sticky|stretch|strict|stroke|stroke-box|style|sub|subgrid|subpixel-antialiased|subtract|super|sw-resize|symbolic|table|table-caption|table-cell
           |table-column|table-column-group|table-footer-group|table-header-group|table-row|table-row-group|tabular-nums|tb|tb-rl|text|text-after-edge
           |text-before-edge|text-bottom|text-top|thick|thin|titling-caps|top|top-outside|touch|traditional|transparent|triangle|ultra-condensed|ultra-expanded
-          |under|underline|unicase|unset|uppercase|upright|upleft|downright|downleft|use-glyph-orientation|use-script|verso|vertical|vertical-ideographic|vertical-lr|vertical-rl
+          |under|underline|unicase|unset|upleft|uppercase|upright|use-glyph-orientation|use-script|verso|vertical|vertical-ideographic|vertical-lr|vertical-rl
           |vertical-text|view-box|visible|visibleFill|visiblePainted|visibleStroke|w-resize|wait|wavy|weight|whitespace|wider|words|wrap|wrap-reverse
           |x-large|x-small|xx-large|xx-small|zero|zoom-in|zoom-out)
           (?![\\w-])


### PR DESCRIPTION
### Description of the Change

Adds syntax coloring for three grid keywords: upleft, downleft, and downright. The keyword "upright" already had syntax highlighting, so this adds it to the other three. Fixes #120. The results can be seen here: http://imgur.com/q902Vk5

### Benefits

More cohesive syntax highlighting.

### Applicable Issues

Fixes #120 
