### PR TITLE
Fix line continuation in other TMCG implementations

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -663,7 +663,8 @@
         'name': 'constant.character.escape.codepoint.css'
       }
       {
-        'match': '\\\\$\\n?'
+        'begin': '\\\\$\\s*'
+        'end': '^(?<!\\G)'
         'name': 'constant.character.escape.newline.css'
       }
       {


### PR DESCRIPTION
### Description of the Change

This PR has absolutely no bearing on Atom: it's strictly for the benefit of VSCode and GitHub, both of which are using this grammar to highlight CSS code. I'm still not sure how or when the discrepancy started happening: I remember this pattern worked for other grammars I worked on... 😞

Anyway, to verify that this fix worked, I installed VSCode in a VirtualBox installation, and modified the VSCode version of the grammar (which was located at `C:\Program Files\Microsoft VS Code\resources\app\extensions\css\syntaxes`). Here's the result:

<img src="https://user-images.githubusercontent.com/2346707/30430495-c3effa12-999e-11e7-8c71-e26785f374d3.png" width="211" alt="Figure 1" />

### Benefits

It'll fix highlighting on GitHub:

~~~css
#testcase::before {
	content: 'long string\
	using line continuation';
}
~~~

### Possible Drawbacks

None. Atom's tests passed without complaint.

### Applicable Issues

Fixes atom/language-css#123