### PR TITLE
adjust tag-names match to fix downstream issue in language-less

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -2032,7 +2032,7 @@
         | mrow|ms|mscarries|mscarry|msgroup|msline|mspace|msqrt|msrow|mstack|mstyle|msub|msubsup
         | msup|mtable|mtd|mtext|mtr|munder|munderover|semantics
       )
-      (?=[+~>\\s,.\\#|){:\\[]|/\\*|$)
+      (?=[+~>\\s,.\\#|){\\[]|/\\*|:[^\\s]|$)
     '''
     'name': 'entity.name.tag.css'
   'unicode-range':


### PR DESCRIPTION
This PR addresses a specificity issue in the tag-names matcher which causes a bug in language-less.

Currently, the `tag-names` matcher ends with a postive lookahead of simply a single colon (among other things) after any of the valid tag names is found. The reason this is a problem is because some tag names are also property names (e.g. `cursor`, `font`, `content`, etc).

To fix this, all that needed to happen is a slight adjustment to the regex to increase the specificity to match only colons followed by a non-space.

#### Drawbacks

There really is no other way I can think of other than having the selector match a colon followed by a non-space because of all the possibilities with pseudo selectors, child selectors, etc. Because of that, there will still be a mistake in some situations where the user forgets to add a space between property keys and values that match tag names. IMHO, that's not the end of the world though.

#### Relevant:

- https://github.com/atom/language-sass/pull/234

Fixes atom/language-less#79