### PR TITLE
Fix mistyped pattern name in css syntax

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1023,7 +1023,7 @@
             'name': 'support.constant.text-direction.css'
           }
           {
-            'include': '#property-value'
+            'include': '#property-values'
           }
         ]
       }


### PR DESCRIPTION
### Description of the Change
Some parameters inside pseudo class **dir** haven't been colorized. It's trivial but it should be fixed.
The reason is the mistypo of pattern name and I just fixed it.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
None

### Benefits

<!-- What benefits will be realized by the code change? -->
We can see pattern colorizing inside dir pseudo class as intended.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None

### Applicable Issues

<!-- Enter any applicable Issues here -->
None
