### PR TITLE
Recognize hyphens as part of words for autocomplete, but not cursor movement

### DIFF
--- a/settings/language-css.cson
+++ b/settings/language-css.cson
@@ -4,6 +4,7 @@
     'commentEnd': '*/'
     'foldEndPattern': '(?<!\\*)\\*\\*/|^\\s*\\}|\\/*\\s*@end\\s*\\*\\/'
   'autocomplete':
+    'extraWordCharacters': '-'
     'symbols':
       'selector':
         'selector': '.css.selector'

--- a/settings/language-css.cson
+++ b/settings/language-css.cson
@@ -1,6 +1,5 @@
 '.source.css':
   'editor':
-    'nonWordCharacters': '/\\()"\':,.;<>~!#$@%^&*|+=[]{}`?…'
     'commentStart': '/*'
     'commentEnd': '*/'
     'foldEndPattern': '(?<!\\*)\\*\\*/|^\\s*\\}|\\/*\\s*@end\\s*\\*\\/'


### PR DESCRIPTION
🍐 'd with @maxbrunsfeld 

Previously, we removed `-` to the `editor.nonWordCharacters` setting to allow words containing dashes to continue to be completed following https://github.com/atom/autocomplete-plus/pull/886. However, this changed cursor movement behavior. This PR reverts that change and *adds* `-` to `autocomplete.extraWordCharacters` to achieve the same effect. Depends on https://github.com/atom/autocomplete-plus/pull/944.