### PR TITLE
Handle syntax highlighting of custom at-rules for Microsoft/vscode-css-languageservice#51

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -584,6 +584,39 @@
             'include': '#string'
           }
         ]
+      },
+      {
+        # @custom-at-rule
+        'begin': '(?i)(?=@[\\w-]+(\\s|\\(|/\\*|$))'
+        'end': '(?<=})(?!\\G)'
+        'patterns': [
+          {
+            'begin': '(?i)\\G(@)[\\w-]+'
+            'beginCaptures':
+              '0':
+                'name': 'keyword.control.at-rule.css'
+              '1':
+                'name': 'punctuation.definition.keyword.css'
+            'end': '(?=\\s*[{;])'
+            'name': 'meta.at-rule.header.css'
+          }
+          {
+            'begin': '{'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.section.begin.bracket.curly.css'
+            'end': '}'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.section.end.bracket.curly.css'
+            'name': 'meta.at-rule.body.css'
+            'patterns': [
+              {
+                'include': '$self'
+              }
+            ]
+          }
+        ]
       }
     ]
   'color-keywords':

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -137,8 +137,8 @@ describe 'CSS grammar', ->
 
       it 'does not tokenise identifiers following an @ symbol', ->
         {tokens} = grammar.tokenizeLine('@some-weird-new-feature')
-        expect(tokens[0]).toEqual value: '@', scopes: ['source.css']
-        expect(tokens[1]).toEqual value: 'some-weird-new-feature', scopes: ['source.css', 'meta.selector.css']
+        expect(tokens[0]).toEqual value: '@', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css', 'punctuation.definition.keyword.css']
+        expect(tokens[1]).toEqual value: 'some-weird-new-feature', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css']
 
       it 'does not tokenise identifiers in unfamiliar functions', ->
         {tokens} = grammar.tokenizeLine('some-edgy-new-function()')
@@ -619,8 +619,8 @@ describe 'CSS grammar', ->
           expect(lines[0][0]).toEqual value: '/*', scopes: ['source.css', 'comment.block.css', 'punctuation.definition.comment.begin.css']
           expect(lines[0][1]).toEqual value: ' Not the first line ', scopes: ['source.css', 'comment.block.css']
           expect(lines[0][2]).toEqual value: '*/', scopes: ['source.css', 'comment.block.css', 'punctuation.definition.comment.end.css']
-          expect(lines[1][0]).toEqual value: '@', scopes: ['source.css']
-          expect(lines[1][1]).toEqual value: 'charset "UTF-8";', scopes: ['source.css', 'meta.selector.css']
+          expect(lines[1][0]).toEqual value: '@', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css', 'punctuation.definition.keyword.css']
+          expect(lines[1][1]).toEqual value: 'charset', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css']
 
         it 'highlights invalid @charset statements', ->
           lines = grammar.tokenizeLines " @charset 'US-ASCII';"


### PR DESCRIPTION
### Description of the Change

This gives some basic highlighting to unknown at-rules. The rules are modeled after `@media`.

For example,

```css
@some-rule () {

}
```

Will now receive correct highlighting on
- `@some-rule` as `keyword.control.at-rule.css`
- `some-rule` as `punctuation.definition.keyword.css`
- Everything between `{` and `}` is tokenized as normal css
- There is no tokenization between `(` and `)`, as we don't know the argument format for the unknown at rule

Before:

![image](https://user-images.githubusercontent.com/4033249/41432094-d316f1ba-6fc9-11e8-9c49-b9a21f35b3e3.png)

After:

![image](https://user-images.githubusercontent.com/4033249/41432102-d8d2575c-6fc9-11e8-9005-ab159775b274.png)

Spec: https://www.w3.org/TR/css-syntax-3/#consume-an-at-rule
Related: https://github.com/Microsoft/vscode-css-languageservice/issues/51
Motivation: Pre-processors that define custom at-rules, for example https://github.com/css-modules/postcss-icss-values

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Benefits

Better syntax highlighting of unknown css rules.

### Possible Drawbacks

None.

### Applicable Issues

https://github.com/Microsoft/vscode-css-languageservice/issues/51