### PR TITLE
New pseudo selectors

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -584,6 +584,39 @@
             'include': '#string'
           }
         ]
+      },
+      {
+        # @custom-at-rule
+        'begin': '(?i)(?=@[\\w-]+(\\s|\\(|/\\*|$))'
+        'end': '(?<=})(?!\\G)'
+        'patterns': [
+          {
+            'begin': '(?i)\\G(@)[\\w-]+'
+            'beginCaptures':
+              '0':
+                'name': 'keyword.control.at-rule.css'
+              '1':
+                'name': 'punctuation.definition.keyword.css'
+            'end': '(?=\\s*[{;])'
+            'name': 'meta.at-rule.header.css'
+          }
+          {
+            'begin': '{'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.section.begin.bracket.curly.css'
+            'end': '}'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.section.end.bracket.curly.css'
+            'name': 'meta.at-rule.body.css'
+            'patterns': [
+              {
+                'include': '$self'
+              }
+            ]
+          }
+        ]
       }
     ]
   'color-keywords':

--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1596,10 +1596,11 @@
         'name': 'invalid.illegal.colon.css'
     'match': '''(?xi)
       (:)(:*)
-      (?: active|any-link|checked|default|disabled|empty|enabled|first
-        | (?:first|last|only)-(?:child|of-type)|focus|focus-within|fullscreen|host|hover
-        | in-range|indeterminate|invalid|left|link|optional|out-of-range
-        | read-only|read-write|required|right|root|scope|target|unresolved
+      (?: active|any-link|checked|default|defined|disabled|empty|enabled|first
+        | (?:first|last|only)-(?:child|of-type)|focus|focus-visible|focus-within
+        | fullscreen|host|hover|in-range|indeterminate|invalid|left|link
+        | optional|out-of-range|placeholder-shown|read-only|read-write
+        | required|right|root|scope|target|unresolved
         | valid|visited
       )(?![\\w-]|\\s*[;}])
     '''

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -137,8 +137,8 @@ describe 'CSS grammar', ->
 
       it 'does not tokenise identifiers following an @ symbol', ->
         {tokens} = grammar.tokenizeLine('@some-weird-new-feature')
-        expect(tokens[0]).toEqual value: '@', scopes: ['source.css']
-        expect(tokens[1]).toEqual value: 'some-weird-new-feature', scopes: ['source.css', 'meta.selector.css']
+        expect(tokens[0]).toEqual value: '@', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css', 'punctuation.definition.keyword.css']
+        expect(tokens[1]).toEqual value: 'some-weird-new-feature', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css']
 
       it 'does not tokenise identifiers in unfamiliar functions', ->
         {tokens} = grammar.tokenizeLine('some-edgy-new-function()')
@@ -619,8 +619,8 @@ describe 'CSS grammar', ->
           expect(lines[0][0]).toEqual value: '/*', scopes: ['source.css', 'comment.block.css', 'punctuation.definition.comment.begin.css']
           expect(lines[0][1]).toEqual value: ' Not the first line ', scopes: ['source.css', 'comment.block.css']
           expect(lines[0][2]).toEqual value: '*/', scopes: ['source.css', 'comment.block.css', 'punctuation.definition.comment.end.css']
-          expect(lines[1][0]).toEqual value: '@', scopes: ['source.css']
-          expect(lines[1][1]).toEqual value: 'charset "UTF-8";', scopes: ['source.css', 'meta.selector.css']
+          expect(lines[1][0]).toEqual value: '@', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css', 'punctuation.definition.keyword.css']
+          expect(lines[1][1]).toEqual value: 'charset', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css']
 
         it 'highlights invalid @charset statements', ->
           lines = grammar.tokenizeLines " @charset 'US-ASCII';"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Add
- `:defined`: https://developer.mozilla.org/en-US/docs/Web/CSS/:defined
- `:focus-visible`: https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo
- `:placeholder-shown`: https://developer.mozilla.org/en-US/docs/Web/CSS/:placeholder-shown

The pseudo selectors are sourced from https://github.com/mdn/data/blob/master/css/selectors.json