### PR TITLE
Add missing scroll-snap-type values

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1403,7 +1403,7 @@
           |text|text-after-edge|text-before-edge|text-bottom|text-top|thick|thin|titling-caps|top|top-outside|touch|traditional|transparent|triangle
           |ultra-condensed|ultra-expanded|under|underline|unicase|unset|upleft|uppercase|upright|use-glyph-orientation|use-script|verso|vertical
           |vertical-ideographic|vertical-lr|vertical-rl|vertical-text|view-box|visible|visibleFill|visiblePainted|visibleStroke|w-resize|wait|wavy
-          |weight|whitespace|wider|words|wrap|wrap-reverse|x-large|x-small|xx-large|xx-small|zero|zoom-in|zoom-out)
+          |weight|whitespace|wider|words|wrap|wrap-reverse|x|x-large|x-small|xx-large|xx-small|y|zero|zoom-in|zoom-out)
           (?![\\w-])
         '''
         'name': 'support.constant.property-value.css'


### PR DESCRIPTION
### Description of the Change

This change only adds some missing values for the `scroll-snap-type` property.

### Alternate Designs

Does not apply.

### Benefits

Adds syntax highlighting for the missing values.

### Possible Drawbacks

Does not apply.

### Applicable Issues

Closes #148 
