### PR TITLE
Fix typo in "highlight deprecated combinators" spec

### DIFF
--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -27,7 +27,7 @@ describe 'CSS grammar', ->
       expect(tokens[6]).toEqual value: '+', scopes: ['source.css', 'meta.selector.css', 'keyword.operator.combinator.css']
       expect(tokens[10]).toEqual value: '~', scopes: ['source.css', 'meta.selector.css', 'keyword.operator.combinator.css']
 
-    it 'highlights deprecated combintors', ->
+    it 'highlights deprecated combinators', ->
       {tokens} = grammar.tokenizeLine '.sooo /deep/ >>>_.>>>'
       expect(tokens[3]).toEqual value: '/deep/', scopes: ['source.css', 'invalid.deprecated.combinator.css']
       expect(tokens[5]).toEqual value: '>>>', scopes: ['source.css', 'invalid.deprecated.combinator.css']


### PR DESCRIPTION
### Requirements

* [x] Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* ❌ All new code requires tests to ensure against regressions. **Not needed here due there's no change in implementation**

### Description of the Change

Fix typo in "highlight deprecated combinators" spec, Replaces "combintors" by "combinators"

### Alternate Designs

it seems that there's no alternate design

### Benefits

Improve text quality and reduce anxiety of people who suffer OCD

### Possible Drawbacks

None

### Applicable Issues

Nope
