### PR TITLE
Fix #160

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -586,8 +586,29 @@
         ]
       },
       {
+        # Single line @custom-at-rule terminated with `;`, such as
+        # @my-rule foo bar;
+        'begin': '(?i)(?=@[\\w-]+[^;]+;\s*$)'
+        'end': '(?<=;)(?!\\G)'
+        'patterns': [
+          {
+            'begin': '(?i)\\G(@)[\\w-]+'
+            'beginCaptures':
+              '0':
+                'name': 'keyword.control.at-rule.css'
+              '1':
+                'name': 'punctuation.definition.keyword.css'
+            'end': ';'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.terminator.rule.css'
+            'name': 'meta.at-rule.header.css'
+          }
+        ]
+      }
+      {
         # @custom-at-rule
-        'begin': '(?i)(?=@[\\w-]+(\\s|\\(|/\\*|$))'
+        'begin': '(?i)(?=@[\\w-]+(\\s|\\(|{|/\\*|$))'
         'end': '(?<=})(?!\\G)'
         'patterns': [
           {

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -735,8 +735,10 @@ describe 'CSS grammar', ->
           expect(tokens[5]).toEqual value: ';', scopes: ['source.css', 'meta.at-rule.import.css', 'punctuation.terminator.rule.css']
 
           {tokens} = grammar.tokenizeLine('@import-file.css;')
-          expect(tokens[0]).toEqual value: '@', scopes: ['source.css']
-          expect(tokens[1]).toEqual value: 'import-file.css;', scopes: ['source.css', 'meta.selector.css']
+          expect(tokens[0]).toEqual value: '@', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css', 'punctuation.definition.keyword.css']
+          expect(tokens[1]).toEqual value: 'import-file', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css']
+          expect(tokens[2]).toEqual value: '.css', scopes: ['source.css', 'meta.at-rule.header.css']
+          expect(tokens[3]).toEqual value: ';', scopes: ['source.css', 'meta.at-rule.header.css', 'punctuation.terminator.rule.css']
 
         it 'matches a URL that starts on the next line', ->
           lines = grammar.tokenizeLines '@import\nurl("file.css");'
@@ -1953,6 +1955,38 @@ describe 'CSS grammar', ->
           expect(lines[1][5]).toEqual value: 'landscape', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.property-value.css']
           expect(lines[1][6]).toEqual value: ';', scopes: ['source.css', 'meta.property-list.css', 'punctuation.terminator.rule.css']
           expect(lines[2][0]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.end.bracket.curly.css']
+
+      describe 'unknown at-rules', ->
+        it 'correctly parses single-line unknown at-rules closing with semicolons', ->
+          lines = grammar.tokenizeLines """
+            @foo;
+            @foo ;
+            @foo a;
+            @foo ();
+            @foo (a);
+          """
+          expect(lines[0][1]).toEqual value: 'foo', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css']
+
+          expect(lines[1][1]).toEqual value: 'foo', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css']
+
+          expect(lines[2][1]).toEqual value: 'foo', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css']
+          expect(lines[2][2]).toEqual value: ' a', scopes: ['source.css', 'meta.at-rule.header.css']
+
+          expect(lines[3][1]).toEqual value: 'foo', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css']
+          expect(lines[3][2]).toEqual value: ' ()', scopes: ['source.css', 'meta.at-rule.header.css']
+
+          expect(lines[4][1]).toEqual value: 'foo', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css']
+          expect(lines[4][2]).toEqual value: ' (a)', scopes: ['source.css', 'meta.at-rule.header.css']
+
+        it 'correctly parses single-line unknown at-rules closing with ;', ->
+          lines = grammar.tokenizeLines """
+            @foo bar;
+            .foo
+          """
+          expect(lines[0][1]).toEqual value: 'foo', scopes: ['source.css', 'meta.at-rule.header.css', 'keyword.control.at-rule.css']
+
+          expect(lines[1][0]).toEqual value: '.', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.class.css', 'punctuation.definition.entity.css']
+          expect(lines[1][1]).toEqual value: 'foo', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.class.css']
 
     describe 'capitalisation', ->
       it 'ignores case in at-rules', ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

As seen in #160, the following code won't be highlighted properly:

```css
@value foo;
.foo
```

This is caused by my change in #142 to eagerly parse a block of `{}` in custom at-rules.
My change introduce a new rule that specifically handle single-line custom at-rules ending with `;`.

### Alternate Designs

n/a

### Benefits

Before:

![image](https://user-images.githubusercontent.com/4033249/58054744-65da2880-7b10-11e9-8516-6d6fb6589aa5.png)

After:

![image](https://user-images.githubusercontent.com/4033249/58054758-725e8100-7b10-11e9-9296-c2400a15d128.png)


### Possible Drawbacks

Before:

![image](https://user-images.githubusercontent.com/4033249/58054816-a2a61f80-7b10-11e9-88a9-ef3073779211.png)

After:

![image](https://user-images.githubusercontent.com/4033249/58054803-97eb8a80-7b10-11e9-9763-bbfb6b4b35ac.png)

Although `@import-file.css` is not valid CSS, I think parsing the `@import-file` part as at-rule follows the spec closer than original behavior.

### Applicable Issues

#160.

<!-- Enter any applicable Issues here -->
