### PR TITLE
Fix #163 by not marking media properties as `invalid.deprecated`

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1196,7 +1196,7 @@
       '1':
         'name': 'support.type.property-name.media.css'
       '2':
-        'name': 'invalid.deprecated.media.css'
+        'name': 'support.type.property-name.media.css'
       '3':
         'name': 'support.type.vendored.property-name.media.css'
     'match': '''(?xi)

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -834,7 +834,7 @@ describe 'CSS grammar', ->
           expect(tokens[0]).toEqual value: '@', scopes: ['source.css', 'meta.at-rule.media.header.css', 'keyword.control.at-rule.media.css', 'punctuation.definition.keyword.css']
           expect(tokens[1]).toEqual value: 'media', scopes: ['source.css', 'meta.at-rule.media.header.css', 'keyword.control.at-rule.media.css']
           expect(tokens[3]).toEqual value: '(', scopes: ['source.css', 'meta.at-rule.media.header.css', 'punctuation.definition.parameters.begin.bracket.round.css']
-          expect(tokens[4]).toEqual value: 'max-device-width', scopes: ['source.css', 'meta.at-rule.media.header.css', 'invalid.deprecated.media.css']
+          expect(tokens[4]).toEqual value: 'max-device-width', scopes: ['source.css', 'meta.at-rule.media.header.css', 'support.type.property-name.media.css']
           expect(tokens[5]).toEqual value: ':', scopes: ['source.css', 'meta.at-rule.media.header.css', 'punctuation.separator.key-value.css']
           expect(tokens[7]).toEqual value: '2', scopes: ['source.css', 'meta.at-rule.media.header.css', 'constant.numeric.css']
           expect(tokens[8]).toEqual value: 'px', scopes: ['source.css', 'meta.at-rule.media.header.css', 'constant.numeric.css', 'keyword.other.unit.px.css']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

As detailed in #163, properties should not be scoped as `invalid.deprecated` easily to cause red syntax highlighting meant for syntax errors.

### Alternate Designs

n/a

### Benefits

Editors still using the TextMate grammar (including older versions of Atom) would be able to use deprecated media queries without seeing the red flagging (they might be targeting old browsers so their usage would be valid).

### Possible Drawbacks

n/a

### Applicable Issues

- https://github.com/atom/language-css/issues/163
- https://github.com/microsoft/vscode/issues/62515
