### PR TITLE
Add grid properties that were not being recognized as supported

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1524,12 +1524,13 @@
             | opacity|order|orientation|orphans|outline|outline-color|outline-offset|outline-style|outline-width|overflow
             | overflow-wrap|overflow-[xy]|pad|padding|padding-block-end|padding-block-start|padding-bottom|padding-inline-end
             | padding-inline-start|padding-left|padding-right|padding-top|page-break-after|page-break-before|page-break-inside
-            | perspective|perspective-origin|pointer-events|position|prefix|quotes|range|resize|right|ruby-align|ruby-merge
-            | ruby-position|scroll-behavior|scroll-snap-coordinate|scroll-snap-destination|scroll-snap-type|shape-image-threshold
-            | shape-margin|shape-outside|speak-as|src|suffix|symbols|system|tab-size|table-layout|text-align|text-align-last
-            | text-combine-upright|text-decoration|text-decoration-color|text-decoration-line|text-decoration-style|text-emphasis
-            | text-emphasis-color|text-emphasis-position|text-emphasis-style|text-indent|text-orientation|text-overflow
-            | text-rendering|text-shadow|text-transform|text-underline-position|top|touch-action|transform|transform-box
+            | perspective|perspective-origin|place-content|place-items|place-self|pointer-events|position|prefix|quotes|range
+            | resize|right|row-gap|ruby-align|ruby-merge|ruby-position|scroll-behavior|scroll-snap-coordinate
+            | scroll-snap-destination|scroll-snap-type|shape-image-threshold|shape-margin|shape-outside|speak-as|src|suffix
+            | symbols|system|tab-size|table-layout|text-align|text-align-last|text-combine-upright|text-decoration
+            | text-decoration-color|text-decoration-line|text-decoration-style|text-emphasis|text-emphasis-color
+            | text-emphasis-position|text-emphasis-style|text-indent|text-orientation|text-overflow|text-rendering
+            | text-shadow|text-transform|text-underline-position|top|touch-action|transform|transform-box
             | transform-origin|transform-style|transition|transition-delay|transition-duration|transition-property
             | transition-timing-function|unicode-bidi|unicode-range|user-zoom|vertical-align|visibility|white-space|widows
             | width|will-change|word-break|word-spacing|word-wrap|writing-mode|z-index|zoom

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -3572,3 +3572,67 @@ describe 'CSS grammar', ->
       """
       for line in invalid.split /\n/
         expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()
+
+  describe "Missing supported properties regressions", ->
+    it "recognises place-items property as supported", ->
+      tokens = grammar.tokenizeLines 'a { place-items: center center; }'
+      expect(tokens[0][0]).toEqual value: 'a', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.css']
+      expect(tokens[0][1]).toEqual value: ' ', scopes: ['source.css']
+      expect(tokens[0][2]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.bracket.curly.css']
+      expect(tokens[0][3]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css']
+      expect(tokens[0][4]).toEqual value: 'place-items', scopes: ['source.css', 'meta.property-list.css', 'meta.property-name.css', 'support.type.property-name.css']
+      expect(tokens[0][5]).toEqual value: ':', scopes: ['source.css', 'meta.property-list.css', 'punctuation.separator.key-value.css']
+      expect(tokens[0][6]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css']
+      expect(tokens[0][7]).toEqual value: 'center', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.property-value.css']
+      expect(tokens[0][8]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css']
+      expect(tokens[0][9]).toEqual value: 'center', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.property-value.css']
+      expect(tokens[0][10]).toEqual value: ';', scopes: ['source.css', 'meta.property-list.css', 'punctuation.terminator.rule.css']
+      expect(tokens[0][11]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css']
+      expect(tokens[0][12]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.end.bracket.curly.css']
+
+    it "recognises place-self property as supported", ->
+      tokens = grammar.tokenizeLines 'a { place-self: center center; }'
+      expect(tokens[0][0]).toEqual value: 'a', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.css']
+      expect(tokens[0][1]).toEqual value: ' ', scopes: ['source.css']
+      expect(tokens[0][2]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.bracket.curly.css']
+      expect(tokens[0][3]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css']
+      expect(tokens[0][4]).toEqual value: 'place-self', scopes: ['source.css', 'meta.property-list.css', 'meta.property-name.css', 'support.type.property-name.css']
+      expect(tokens[0][5]).toEqual value: ':', scopes: ['source.css', 'meta.property-list.css', 'punctuation.separator.key-value.css']
+      expect(tokens[0][6]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css']
+      expect(tokens[0][7]).toEqual value: 'center', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.property-value.css']
+      expect(tokens[0][8]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css']
+      expect(tokens[0][9]).toEqual value: 'center', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.property-value.css']
+      expect(tokens[0][10]).toEqual value: ';', scopes: ['source.css', 'meta.property-list.css', 'punctuation.terminator.rule.css']
+      expect(tokens[0][11]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css']
+      expect(tokens[0][12]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.end.bracket.curly.css']
+
+    it "recognises place-content property as supported", ->
+      tokens = grammar.tokenizeLines 'a { place-content: center center; }'
+      expect(tokens[0][0]).toEqual value: 'a', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.css']
+      expect(tokens[0][1]).toEqual value: ' ', scopes: ['source.css']
+      expect(tokens[0][2]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.bracket.curly.css']
+      expect(tokens[0][3]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css']
+      expect(tokens[0][4]).toEqual value: 'place-content', scopes: ['source.css', 'meta.property-list.css', 'meta.property-name.css', 'support.type.property-name.css']
+      expect(tokens[0][5]).toEqual value: ':', scopes: ['source.css', 'meta.property-list.css', 'punctuation.separator.key-value.css']
+      expect(tokens[0][6]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css']
+      expect(tokens[0][7]).toEqual value: 'center', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.property-value.css']
+      expect(tokens[0][8]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css']
+      expect(tokens[0][9]).toEqual value: 'center', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.property-value.css']
+      expect(tokens[0][10]).toEqual value: ';', scopes: ['source.css', 'meta.property-list.css', 'punctuation.terminator.rule.css']
+      expect(tokens[0][11]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css']
+      expect(tokens[0][12]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.end.bracket.curly.css']
+
+    it "recognises row-gap property as supported", ->
+      tokens = grammar.tokenizeLines 'a { row-gap: 5px; }'
+      expect(tokens[0][0]).toEqual value: 'a', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.css']
+      expect(tokens[0][1]).toEqual value: ' ', scopes: ['source.css']
+      expect(tokens[0][2]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.bracket.curly.css']
+      expect(tokens[0][3]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css']
+      expect(tokens[0][4]).toEqual value: 'row-gap', scopes: ['source.css', 'meta.property-list.css', 'meta.property-name.css', 'support.type.property-name.css']
+      expect(tokens[0][5]).toEqual value: ':', scopes: ['source.css', 'meta.property-list.css', 'punctuation.separator.key-value.css']
+      expect(tokens[0][6]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css']
+      expect(tokens[0][7]).toEqual value: '5', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'constant.numeric.css']
+      expect(tokens[0][8]).toEqual value: 'px', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'constant.numeric.css', 'keyword.other.unit.px.css']
+      expect(tokens[0][9]).toEqual value: ';', scopes: ['source.css', 'meta.property-list.css', 'punctuation.terminator.rule.css']
+      expect(tokens[0][10]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css']
+      expect(tokens[0][11]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.end.bracket.curly.css']


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

The following properties were not being tagged as supported properties:
- `row-gap`
- `place-items`
- `place-self`
- `place-content`

This pull request fixes this issue by adding the above-mentioned properties to the supported
properties Regex Pattern.

### Alternate Designs

None

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

All the new grid properties will now be the same colour as other supported properties.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

None

### Applicable Issues

None
