### PR TITLE
Updating pseudo-classes to add defined, focus-visible and placeholder-shown

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1620,11 +1620,11 @@
         'name': 'invalid.illegal.colon.css'
     'match': '''(?xi)
       (:)(:*)
-      (?: active|any-link|checked|default|disabled|empty|enabled|first
-        | (?:first|last|only)-(?:child|of-type)|focus|focus-within|fullscreen|host|hover
-        | in-range|indeterminate|invalid|left|link|optional|out-of-range
-        | read-only|read-write|required|right|root|scope|target|unresolved
-        | valid|visited
+      (?: active|any-link|checked|default|defined|disabled|empty|enabled|first
+        | (?:first|last|only)-(?:child|of-type)|focus|focus-visible|focus-within
+        | fullscreen|host|hover|in-range|indeterminate|invalid|left|link
+        | optional|out-of-range|placeholder-shown|read-only|read-write
+        | required|right|root|scope|target|unresolved|valid|visited
       )(?![\\w-]|\\s*[;}])
     '''
     'name': 'entity.other.attribute-name.pseudo-class.css'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Similar to #173 , this PR includes changes that were added to octref/language-css

This time, three pseudo-classes were added: `defined`, `focus-visible`, and `placeholder-shown`

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Adds more recent pseudo-classes

### Possible Drawbacks

Nothing major

### Applicable Issues

https://github.com/microsoft/vscode/issues/115480
