### PR TITLE
Added accent-color to syntax highlighting

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1493,7 +1493,7 @@
         'match': '''(?xi) (?<![\\w-])
           (?:
             # Standard CSS
-            additive-symbols|align-content|align-items|align-self|all|animation|animation-delay|animation-direction|animation-duration
+            accent-color|additive-symbols|align-content|align-items|align-self|all|animation|animation-delay|animation-direction|animation-duration
             | animation-fill-mode|animation-iteration-count|animation-name|animation-play-state|animation-timing-function|backdrop-filter
             | backface-visibility|background|background-attachment|background-blend-mode|background-clip|background-color|background-image
             | background-origin|background-position|background-position-[xy]|background-repeat|background-size|bleed|block-size|border


### PR DESCRIPTION
### Description of the Change

This PR adds the new "accent-color" keyword to CSS Files as recommended [here](https://github.com/microsoft/vscode/pull/132498).

https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color

### Benefits

The "accent-color" keyword will be highlighted in CSS Files.
