### PR TITLE
Add new color functions to CSS grammar

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -828,7 +828,7 @@
       }
       # Colours
       {
-        'begin': '(?i)(?<![\\w-])(rgba?|hsla?)(\\()'
+        'begin': '(?i)(?<![\\w-])(rgba?|hsla?|hwb|lab|lch)(\\()'
         'beginCaptures':
           '1':
             'name': 'support.function.misc.css'


### PR DESCRIPTION
docs : 

- https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hwb()
- https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/lab()
- https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/lch()

Intention is to have syntax highlighting in the same fashion as `rgb`

<img width="201" alt="Screenshot 2022-02-09 at 14 30 17" src="https://user-images.githubusercontent.com/11521496/153211071-1026a4cd-ac32-4e8a-a647-f3aafc131e28.png">

